### PR TITLE
Fix #52, Fix Table Field to EDT creation - string size not being copied to the EDT, Update TableFieldEDTCreatorMenuAddIn.cs

### DIFF
--- a/SSD365VSAddIn/SSD365VSAddIn/Tables/TableFieldEDTCreatorMenuAddIn.cs
+++ b/SSD365VSAddIn/SSD365VSAddIn/Tables/TableFieldEDTCreatorMenuAddIn.cs
@@ -166,18 +166,42 @@ namespace SSD365VSAddIn.Tables
         }
         private void copyProperties(object source, object target)
         {
+            var propertyMap = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("StringSizeDesignTime",  "StringSize")//,
+                //new KeyValuePair<string, string>("SourcePropertyName",  "TargetPropertyName") -- add in new fields that doesnt match
+            };
             foreach (var prop in source.GetType().GetProperties())
             {
                 var targetProperty = target.GetType().GetProperty(prop.Name);
+                
                 if (targetProperty != null)
                 {
                     targetProperty.SetValue(target, prop.GetValue(source));
+                }
+                else
+                {
+                    //if targetProperty not found with same name as Source Property, check if an alternative property exists from our map
+                    var targetMappedProperty = propertyMap.FirstOrDefault(x => x.Key == prop.Name);
+                    if(! String.IsNullOrEmpty(targetMappedProperty.Value))
+                    {
+                        targetProperty = target.GetType().GetProperty(targetMappedProperty.Value);
+                        if (targetProperty.GetValue(target).GetType() == typeof(Int32))
+                        {
+                            var sourceValue = Int32.Parse(prop.GetValue(source).ToString());
+                            targetProperty.SetValue(target, sourceValue);
+                        }
+                        else
+                        {
+                            targetProperty.SetValue(target, prop.GetValue(source));
+                        }
+                    }
                 }
             }
             foreach (var fields in source.GetType().GetFields())
             {
                 var targetField = target.GetType().GetField(fields.Name);
-                if(targetField != null)
+                if (targetField != null)
                 {
                     targetField.SetValue(target, fields.GetValue(source));
                 }


### PR DESCRIPTION
Fix Table Field to EDT creation - string size not being copied to the EDT

Root cause : IBaseField did not have the property name "StringSize" instead had "StringSizeDesignTime"